### PR TITLE
change: change to return uint64_t from `get_current_ms_time` 

### DIFF
--- a/include/utils/sge_time.h
+++ b/include/utils/sge_time.h
@@ -4,9 +4,10 @@
 
 #ifndef SGE_TIME_H
 #define SGE_TIME_H
+#include <stdint.h>
 
 char* current_time_formatted(void);
-int get_current_ms_time(void);
+uint64_t get_current_ms_time(void);
 int get_current_year(void);
 int get_current_month(void);
 int get_current_day(void);

--- a/src/utils/sge_time.c
+++ b/src/utils/sge_time.c
@@ -19,10 +19,20 @@ char *current_time_formatted(void) {
         return current_time_formatted;
 }
 
-int get_current_ms_time(void) {
-        const DWORD current_ms = GetTickCount64();
+uint64_t get_current_ms_time(void) {
+#ifdef WIN32
+        const uint64_t current_ms = GetTickCount64();
         return current_ms;
+#elif UNIX
+        struct timeval tv;
+
+        gettimeofday(&tv,NULL);
+        return (((long long)tv.tv_sec)*1000)+(tv.tv_usec/1000);
+#else
+        return 0;
+#endif
 }
+
 
 int get_current_year(void) {
         const time_t now = time(NULL);


### PR DESCRIPTION
change: change to return uint64_t from `get_current_ms_time` and make cross platform (#25)